### PR TITLE
Fix vegpfromhab: minor fix to allow for PAI input

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata
+src/*.o
+src/*.so
+src/*.dll

--- a/R/dataprep.R
+++ b/R/dataprep.R
@@ -909,7 +909,7 @@ vegpfromhab <- function(habitats, hgts = NA, pai = NA, lat = NA, long = NA, tme 
   uh<-unique(as.vector(m))
   uh<-uh[is.na(uh)==F]
   # pai test
-  pte<-base::mean(pai,na.rm=T)
+  pte<-base::mean(values(pai),na.rm=T)
   # Create blank array for pai
   if (is.na(pte)) {
     paii<-.paifromhabitat(1, lat, long, tme)
@@ -930,7 +930,7 @@ vegpfromhab <- function(habitats, hgts = NA, pai = NA, lat = NA, long = NA, tme 
     leafd[sel]<-vegi$leafd
     hgt[sel]<-vegi$hgt
   }
-  pai<-.rast(pai,habitats)
+  if (is.na(pte)) {pai<-.rast(pai,habitats)}
   leaft<-0.5*leafr
   clump<-pai*0
   if (clump0 == F) {

--- a/microclimf.Rproj
+++ b/microclimf.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 29c9688a-a182-495e-84e9-1271630dd8f9
 
 RestoreWorkspace: Default
 SaveWorkspace: Default


### PR DESCRIPTION
This PR resolves an error in vegpfromhab() where base::mean() was applied to a SpatRaster object, returning NA.

Changes:

Replaces mean(pai) with mean(values(pai)) to correctly calculate mean PAI.

Function now supports terra-based SpatRaster inputs and avoids silent NA returns.

Added conditional pai <- .rast(pai, habitats) only when PAI was generated from scratch (i.e., when pte is NA), avoiding overwriting user-provided raster stacks.