### PR TITLE
Avoid faulty cropping in .arrayonecellcheck and resampleclimdata

### DIFF
--- a/R/dataprep.R
+++ b/R/dataprep.R
@@ -1210,7 +1210,7 @@ resampleclimdata <- function(climarrayr, dtm) {
   climarrayr <- .unpackclim(climarrayr)
   if (class(dtm)[1] == "PackedSpatRaster") dtm<-rast(dtm)
   rte <- climarrayr[[1]]
-  rte <- crop(rte, ext(dtm))
+  rte <- crop(rte, ext(dtm), snap = "out")
   n <- min(dim(rte)[1:2])
   if (n < 3) {
     ## convert wind speed and direction to u & v wind vector
@@ -1230,7 +1230,7 @@ resampleclimdata <- function(climarrayr, dtm) {
     r<-extend(r,ext(climarrayr[[i]]))
     for (i in 1:9) {
       climarrayr[[i]]  <- resample(climarrayr[[i]], r)
-      climarrayr[[i]] <- crop(climarrayr[[i]], dtm)
+      climarrayr[[i]] <- crop(climarrayr[[i]], dtm, snap = "out")
     }
     # convert back to wind speed and direction
     ws <- sqrt(climarrayr[[7]]^2 + climarrayr[[8]]^2)

--- a/R/dataprep.R
+++ b/R/dataprep.R
@@ -1227,7 +1227,7 @@ resampleclimdata <- function(climarrayr, dtm) {
     res(r) <- res(dtm)
     n2 <- min(dim(r)[1:2])
     r<-aggregate(r, floor(n2/3))
-    r<-extend(r,ext(climarrayr[[i]]))
+    r<-extend(r,ext(climarrayr[[1]]))
     for (i in 1:9) {
       climarrayr[[i]]  <- resample(climarrayr[[i]], r)
       climarrayr[[i]] <- crop(climarrayr[[i]], dtm, snap = "out")

--- a/R/internal.R
+++ b/R/internal.R
@@ -3719,7 +3719,7 @@ flowacc<-function (dtm, basins = NA) {
 # check whether grid version of model should be used
 .arrayonecellcheck <- function(climarrayr, dtm) {
   rte<-climarrayr$temp[[1]]
-  rte<-crop(rte,dtm)
+  rte<-crop(rte,dtm,snap="out")
   dmcheck <-dim(rte)[1]*dim(rte)[2]
   if (dmcheck == 1) stop("Only one grid cell of the climate data overlaps with dtm.
                          Use data.frame version of model or resample climate data to


### PR DESCRIPTION
`.arrayonecellcheck` and `resampleclimdata` previously used `crop` with default options, i.e. `snap = "near"`, which discarded one cell of my `climarrayr` and cut off my input `dtm` (and, as a result, my output area). 

I suggest using `crop()` with `snap = "out"` avoid this behaviour.

In addition, I suggest a bugfix in `resampleclimdata`, which had a non-provided index `[[i]]` for deriving an `ext` from `climarrayr` (sorry, should perhaps have put this into a separate request).