### PR TITLE
vegpfromhab fixes

### DIFF
--- a/R/dataprep.R
+++ b/R/dataprep.R
@@ -911,7 +911,7 @@ vegpfromhab <- function(habitats, hgts = NA, pai = NA, lat = NA, long = NA, tme 
   uh<-unique(as.vector(m))
   uh<-uh[is.na(uh)==F]
   # pai test
-  pte<-base::mean(pai,na.rm=T)
+  base::mean(terra::values(pai_local), na.rm = T)
   # Create blank array for pai
   if (is.na(pte)) {
     paii<-.paifromhabitat(1, lat, long, tme)

--- a/R/dataprep.R
+++ b/R/dataprep.R
@@ -911,7 +911,7 @@ vegpfromhab <- function(habitats, hgts = NA, pai = NA, lat = NA, long = NA, tme 
   uh<-unique(as.vector(m))
   uh<-uh[is.na(uh)==F]
   # pai test
-  base::mean(terra::values(pai_local), na.rm = T)
+  pte <- base::mean(terra::values(pai), na.rm = T)
   # Create blank array for pai
   if (is.na(pte)) {
     paii<-.paifromhabitat(1, lat, long, tme)

--- a/R/dataprep.R
+++ b/R/dataprep.R
@@ -937,7 +937,6 @@ vegpfromhab <- function(habitats, hgts = NA, pai = NA, lat = NA, long = NA, tme 
   leaft<-0.5*leafr
   if (clump0 == F) {
     for (i in 1:dim(pai)[3]) clump[,,i]<-clumpestimate(hgt, leafd, .is(pai)[,,i])
-    clump <- .rast(clump,habitats)
   }
   # Convert to rasters
   if (class(hgts)=="logical") {
@@ -948,6 +947,7 @@ vegpfromhab <- function(habitats, hgts = NA, pai = NA, lat = NA, long = NA, tme 
   leafr<-.rast(leafr,habitats)
   leaft<-.rast(leaft,habitats)
   leafd<-.rast(leafd,habitats)
+  clump <- .rast(clump,habitats)
   vegp<-list(pai=wrap(pai),hgt=wrap(hgt),x=wrap(x),gsmax=wrap(gsmax),leafr=wrap(leafr),clump=wrap(clump),leafd=wrap(leafd),leaft=wrap(leaft))
   class(vegp)<-"vegparams"
   return(vegp)


### PR DESCRIPTION
Two fixes here. This was in response to a bug in `vegpfromhab` that now occurs even with in-built `habitat` data (I tried on two different machines to confirm first, using R 4.1 and 4.3):

For instance here's the code from the function documentation for `vegpfromhab`, which returns an error:
```
library(terra)
tme<-as.POSIXlt(c(0:8783)*3600,origin="2000-01-01 00:00", tz = "GMT")
veg<-vegpfromhab(habitats,lat=50,long=-5,tme=tme)

Error in (function (classes, fdef, mtable)  : 
  unable to find an inherited method for function ‘wrap’ for signature ‘"array"’
```

1. Fix clump


this line of code:
```
clump <- .rast(clump, habitats)
```

was only run if clump0 == F. But `clump` needs to be a spatRaster even if clump0 == T. `clump` inherits its class from `pai`, and if is.na(pte) == T then `pai` is an array....therefore clump will be an array too (and thus needs to be converted to spatRaster


2. Fix NA-checking pai

This line of code:
```
pte <- base::mean(pai, na.rm = T)
```
Seems to be used to test if all `pai` values are NA. Given that `pai` is a spatRaster, not array, if a user is using a recent version of terra then `base::mean(pai, na.rm = T)` will return NA even if `pai` has values. 

So, this was changed to:
```
pte <- base::mean(terra::values(pai), na.rm = T)
```
